### PR TITLE
Python 3.2 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,8 @@ Changes
 
 - Updated tests to run with current `colander` versions.
 
+- Made compatible with Python 3.2.
+
 
 0.1.0a (2012-03-24)
 ~~~~~~~~~~~~~~~~~~~

--- a/colanderalchemy/__init__.py
+++ b/colanderalchemy/__init__.py
@@ -5,7 +5,7 @@
 # This module is part of ColanderAlchemy and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
-from types import SQLAlchemyMapping
-from utils import MappingRegistry
+from .types import SQLAlchemyMapping
+from .utils import MappingRegistry
 
 __all__ = ['SQLAlchemyMapping', 'MappingRegistry']

--- a/colanderalchemy/types.py
+++ b/colanderalchemy/types.py
@@ -7,7 +7,7 @@
 
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm import object_mapper
-from utils import MappingRegistry
+from .utils import MappingRegistry
 import colander
 import sqlalchemy.types
 
@@ -22,7 +22,7 @@ class SQLAlchemyMapping(colander.SchemaNode):
         super(SQLAlchemyMapping, self).__init__(colander.Mapping())
         self._reg = MappingRegistry(cls, excludes, includes, nullables)
 
-        for name, obj in self._reg.attrs.iteritems():
+        for name, obj in self._reg.attrs.items():
             if name in self._reg.excludes:
                 continue
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ An helper tool for autogenerating Colander schemas based on SQLAlchemy mapped cl
                    'Intended Audience :: Developers',
                    'Programming Language :: Python',
                    'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3.2',
                    'License :: OSI Approved :: MIT License',
                    'Operating System :: OS Independent'],
       keywords='serialize deserialize validate schema validation colander sqlalchemy',

--- a/tests.py
+++ b/tests.py
@@ -13,6 +13,7 @@ import sqlalchemy
 import sqlalchemy.ext.declarative
 import sqlalchemy.orm
 import sqlalchemy.schema
+import sys
 import unittest
 
 
@@ -20,12 +21,20 @@ log = logging.getLogger(__name__)
 Base = sqlalchemy.ext.declarative.declarative_base()
 
 
+# True if we are running on Python 3.
+PY3 = sys.version_info[0] == 3
+
+if PY3: # pragma: no cover
+    u = lambda x: x
+else:
+    u = unicode
+
 class Account(Base):
     __tablename__ = 'accounts'
     email = sqlalchemy.Column(sqlalchemy.Unicode(256), primary_key=True)
     name = sqlalchemy.Column(sqlalchemy.Unicode(128), nullable=False)
     surname = sqlalchemy.Column(sqlalchemy.Unicode(128), nullable=False)
-    gender = sqlalchemy.Column(sqlalchemy.Enum(u'M', u'F'), nullable=False)
+    gender = sqlalchemy.Column(sqlalchemy.Enum(u('M'), u('F')), nullable=False)
     contact = sqlalchemy.orm.relationship('Contact', uselist=False,
     back_populates='account')
     themes = sqlalchemy.orm.relationship('Theme', back_populates='author')
@@ -44,7 +53,7 @@ class Contact(Base):
 class Theme(Base):
     __tablename__ = 'themes'
     name = sqlalchemy.Column(sqlalchemy.Unicode(256), primary_key=True)
-    description = sqlalchemy.Column(sqlalchemy.UnicodeText, default=u'')
+    description = sqlalchemy.Column(sqlalchemy.UnicodeText, default=u(''))
     author_id = sqlalchemy.Column(sqlalchemy.Unicode(256),
     sqlalchemy.ForeignKey('accounts.email'),
     primary_key=True)
@@ -200,7 +209,7 @@ class TestsBase(unittest.TestCase):
     def test_includes(self):
         includes = ('email',)
         account = colanderalchemy.SQLAlchemyMapping(Account, includes=includes)
-        self.assertEqual(account.serialize({}).keys(), ['email'])
+        self.assertEqual(list(account.serialize({}).keys()), ['email'])
 
         self.assertRaises(ValueError, colanderalchemy.SQLAlchemyMapping, Account, ('contact',), includes)
 


### PR DESCRIPTION
- Mentioned supported Python versions in trove classifiers.
- Updated tests to run with current `colander` versions.
- Made compatible with Python 3.2.
- Started a change log in README.rst
