### PR TITLE
Increase SQLAlchemySchemaNode configurability and minor fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,8 @@ CHANGELOG
     - Read Colander node init settings for a mapped class using the
       ``__colanderalchemy__`` attribute.  This allows for full customisation
       of the resulting ``colander.Mapping`` SchemaNode. 
+    - Allow non-SQLAlchemy schema nodes within ``SQLAlchemySchemaNode``.
+      Previously, the ``dictify`` method would throw an ``AttributeError``.
 
 - 0.1b7 (Unreleased)
     - Ensure relationships are mapped recursively and adhere to

--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -356,13 +356,19 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
                 value = getattr(obj, name)
 
             except AttributeError:
-                prop = getattr(self.inspector.relationships, name)
-                if prop.uselist:
-                    value = [self[name].children[0].dictify(o)
-                             for o in getattr(obj, name)]
-                else:
-                    o = getattr(obj, name)
-                    value = None if o is None else self[name].dictify(o)
+                try:
+                    prop = getattr(self.inspector.relationships, name)
+                    if prop.uselist:
+                        value = [self[name].children[0].dictify(o)
+                                 for o in getattr(obj, name)]
+                    else:
+                        o = getattr(obj, name)
+                        value = None if o is None else self[name].dictify(o)
+                except AttributeError:
+                    # The given node isn't part of the SQLAlchemy model
+                    msg = 'SQLAlchemySchemaNode.dictify: %s not found on %s'
+                    log.debug(msg, name, self)
+                    continue
 
             dict_[name] = value
 


### PR DESCRIPTION
This pull request:
- Adds the ability for any keyword arguments to be passed to `SQLAlchemySchemaNode` during **init** -- which in turn get passed to the SchemaNode **init**.  This allows `SQLAlchemySchemaNode` to accept all options that its parent class does.
- Allows for the configuration of the `Colander.Mapping` nodes that are produced (eg part of Sequence()/SQL relationships) by way of an attribute on the given mapped class (`__colanderalchemy__ = {'widget': ..., 'title': 'My Object'}`, for instance).  
- Fixes a bug preventing schema nodes that weren't mapped to an SQLAlchemy attribute from allowing the `dictify()` function to run.  Now, non-SQLAlchemy nodes are ignored with a debug message logged.  (Useful in the case of adding something like a CSRF or CAPTCHA field to a schema -- something that shouldn't be stored in the database, but is needed all the same)

I've noticed that the documentation for v0.2 of ColanderAlchemy is still that v0.1.  So, I'm more than happy to update the doco for the new iteration of ColanderAlchemy -- will this fine for inclusion?  If so, I'll get started on it and when I'm done, I'll send a pull request.  
