### PR TITLE
Increase SQLAlchemySchemaNode configurability and minor fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,12 @@
 CHANGELOG
 
+- 0.2 (Unreleased)
+    - Read Colander node init settings for a mapped class using the
+      ``__colanderalchemy__`` attribute.  This allows for full customisation
+      of the resulting ``colander.Mapping`` SchemaNode. 
+    - Allow non-SQLAlchemy schema nodes within ``SQLAlchemySchemaNode``.
+      Previously, the ``dictify`` method would throw an ``AttributeError``.
+
 - 0.1b7 (Unreleased)
     - Ensure relationships are mapped recursively and adhere to
       ColanderAlchemy settings for mappings.

--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -38,21 +38,27 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
     """
 
     sqla_info_key = 'colanderalchemy'
+    ca_class_key = '__colanderalchemy_config__'
 
     def __init__(self, class_, includes=None,
-                 excludes=None, overrides=None, unknown='raise'):
+                 excludes=None, overrides=None, unknown='raise', **kw):
 
         log.debug('SQLAlchemySchemaNode.__init__: %s', class_)
 
+        self.inspector = inspect(class_)
+        kwargs = kw.copy()
+
+        # Obtain configuration specific from the mapped class
+        kwargs.update(getattr(self.inspector.class_, self.ca_class_key, {}))
+
         # The default type of this SchemaNode is Mapping.
-        colander.SchemaNode.__init__(self, Mapping(unknown))
+        colander.SchemaNode.__init__(self, Mapping(unknown), **kwargs)
         self.class_ = class_
         self.includes = includes or {}
         self.excludes = excludes or {}
         self.overrides = overrides or {}
         self.unknown = unknown
         self.declarative_overrides = {}
-        self.inspector = inspect(class_)
         self.add_nodes(self.includes, self.excludes, self.overrides)
 
     def add_nodes(self, includes, excludes, overrides):
@@ -350,13 +356,19 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
                 value = getattr(obj, name)
 
             except AttributeError:
-                prop = getattr(self.inspector.relationships, name)
-                if prop.uselist:
-                    value = [self[name].children[0].dictify(o)
-                             for o in getattr(obj, name)]
-                else:
-                    o = getattr(obj, name)
-                    value = None if o is None else self[name].dictify(o)
+                try:
+                    prop = getattr(self.inspector.relationships, name)
+                    if prop.uselist:
+                        value = [self[name].children[0].dictify(o)
+                                 for o in getattr(obj, name)]
+                    else:
+                        o = getattr(obj, name)
+                        value = None if o is None else self[name].dictify(o)
+                except AttributeError:
+                    # The given node isn't part of the SQLAlchemy model
+                    msg = 'SQLAlchemySchemaNode.dictify: %s not found on %s'
+                    log.debug(msg, name, self)
+                    continue
 
             dict_[name] = value
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -30,6 +30,7 @@ key = SQLAlchemySchemaNode.sqla_info_key
 class Account(Base):
 
     __tablename__ = 'accounts'
+    __colanderalchemy_config__ = {'preparer': 'DummyPreparer'}
     email = Column(Unicode(64), primary_key=True)
     enabled = Column(Boolean, default=True)
     created = Column(DateTime, nullable=True, default=datetime.datetime.now)
@@ -41,6 +42,8 @@ class Account(Base):
 class Person(Base):
 
     __tablename__ = 'people'
+    __colanderalchemy_config__ = {'widget': 'DummyWidget',
+                                  'title': 'Person Object'}
 
     id = Column(Integer, primary_key=True, info={key: {'typ': colander.Float}})
     name = Column(Unicode(32), nullable=False)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -284,6 +284,9 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         }
         includes = ['email', 'enabled', 'created', 'timeout', 'person']
         schema = SQLAlchemySchemaNode(Account, includes=includes, overrides=overrides)
+        #Add a non-SQLAlchemy field
+        schema.add(colander.SchemaNode(colander.String, name='non_sql'))
+
         args = dict(street='My Street', city='My City')
         address = Address(**args)
         kws = dict(name='My Name', surname='My Surname', gender='M', addresses=[address])
@@ -312,3 +315,25 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
 
         self.assertEqual([node.name for node in schema.children],
                          [node.name for node in cloned.children])
+
+    def test_schemanode_arguments(self):
+        """ Test that any arguments to SchemaNode are accepted.
+        """
+        schema = SQLAlchemySchemaNode(Account,
+                                      widget='DummyWidget',
+                                      title='Dummy',
+                                      non_standard='Not a Colander arg')
+        self.assertEqual(schema.widget, 'DummyWidget')
+        self.assertEqual(schema.title, 'Dummy')
+        self.assertEqual(schema.non_standard, 'Not a Colander arg')
+
+    def test_read_mapping_configuration(self):
+        """ Test using ``__colanderalchemy_config__`` for a mapped class.
+        """
+        schema = SQLAlchemySchemaNode(Account)
+        self.assertEqual(schema.preparer, 'DummyPreparer')
+
+        #Related models will be configured as well
+        self.assertEqual(schema['person'].widget, 'DummyWidget')
+        self.assertEqual(schema['person'].title, 'Person Object')
+


### PR DESCRIPTION
- Adds the ability for any keyword arguments to be passed to `SQLAlchemySchemaNode` during **init** -- which in turn get passed to the SchemaNode **init**.  This allows `SQLAlchemySchemaNode` to accept all options that its parent class does.
- Allows for the configuration of the `Colander.Mapping` nodes that are produced (eg part of Sequence()/SQL relationships) by way of an attribute on the given mapped class (`__colanderalchemy__ = {'widget': ..., 'title': 'My Object'}`, for instance).  
- Fixes a bug preventing schema nodes that weren't mapped to an SQLAlchemy attribute from allowing the `dictify()` function to run.  Now, non-SQLAlchemy nodes are ignored with a debug message logged.  (Useful in the case of adding something like a CSRF or CAPTCHA field to a schema -- something that shouldn't be stored in the database, but is needed all the same)

I've noticed that the documentation for v0.2 of ColanderAlchemy is still that v0.1.  So, I'm more than happy to update the doco for the new iteration of ColanderAlchemy -- will this fine for inclusion?  If so, I'll get started on it and when I'm done, I'll send a pull request.  

Might also be worth noting that whilst the Python 2.7 tests pass, something goes haywire with the 3.2 tests (seems distutils related, but I could be wrong).
