### PR TITLE
Document (almost) everything + change setup_schema function

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 CHANGELOG
 
 - 0.2 (Unreleased)
+    - Drop ``mapper`` argument from the ``setup_schema`` function. It wasn't
+      being used.
     - Read Colander node init settings for a mapped class using the
       ``__colanderalchemy__`` attribute.  This allows for full customisation
       of the resulting ``colander.Mapping`` SchemaNode. 

--- a/colanderalchemy/__init__.py
+++ b/colanderalchemy/__init__.py
@@ -13,5 +13,18 @@ __all__ = ['SQLAlchemySchemaNode']
 __colanderalchemy__ = '__colanderalchemy__'
 
 
-def setup_schema(mapper, class_):
+def setup_schema(class_):
+    """ Build a Colander schema for ``class_`` and attach it to that class.
+
+    Configuration for the resulting Colander schema can be customised by
+    using either ``info`` against columns or relationships, or
+    ``__colanderalchemy_config__`` against individual mapped classes.
+    
+    Arguments/Keywords
+
+    class\_
+        A pre-existing SQLAlchemy mapped class. This class may have
+        attributes, related mapped classes (via SQLAlchemy relationships)
+        and the like.
+    """
     setattr(class_, __colanderalchemy__, SQLAlchemySchemaNode(class_))

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,34 +3,14 @@
 ColanderAlchemy API
 ===================
 
-Declarative Classes
-~~~~~~~~~~~~~~~~~~~
+.. automodule:: colanderalchemy
 
-.. automodule:: colanderalchemy.declarative
-
-  .. autoclass:: Column
+  .. autoclass:: SQLAlchemySchemaNode
   
      .. automethod:: __init__
+     .. automethod:: dictify
+     .. automethod:: get_schema_from_column
+     .. automethod:: get_schema_from_relationship
 
-  .. autofunction:: relationship
-
-Types
-~~~~~
-
-.. automodule:: colanderalchemy.types
-
-  .. autoclass:: SQLAlchemyMapping
-     :members:
-
-     .. automethod:: __init__
-
-
-Utilities
-~~~~~~~~~
-
-.. automodule:: colanderalchemy.utils
-
-  .. autoclass:: MappingRegistry
-
-     .. automethod:: __init__
+  .. autofunction:: setup_schema
 

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -1,10 +1,13 @@
 .. _customization:
 
-Change auto-generation rules
-============================
+Customization
+=============
 
-The default ``Colander`` schema generated using ``SQLAlchemyMapping`` follows
-the rules below:
+Changing auto-generation rules
+------------------------------
+
+The default ``Colander`` schema generated using
+:class:`colanderalchemy.SQLAlchemySchemaNode` follows the rules below:
 
 #. It has an `optional` (not required) field for each optional column and for
    each relationship
@@ -15,31 +18,64 @@ the rules below:
 
 #. It validates ``Enum`` columns using the Colander ``OneOf`` validator
 
-The user can change default behaviour of ``SQLAlchemyMapping`` by specifying
-the keyword arguments ``includes``, ``excludes``, and ``nullables``.
+You can change the default behaviour of
+:class:`colanderalchemy.SQLAlchemySchemaNode` by specifying the keyword
+arguments ``includes``, ``excludes``, and ``overrides``.  
 
-Read `tests
+Refer to the API for :class:`colanderalchemy.SQLAlchemySchemaNode` and the
+`tests
 <https://github.com/stefanofontanelli/ColanderAlchemy/blob/master/tests.py>`_
 to understand how they work.
 
-You can subclass the following ``SQLAlchemyMapping`` methods when you need
-more customization:
+This class also accepts all keyword arguments that could normally be passed to
+a basic :class:`colander.SchemaNode`, such as `title`, `description`,
+`preparer`, and more. Read more about basic Colander customisation at
+http://docs.pylonsproject.org/projects/colander/en/latest/basics.html.
 
-* ``get_schema_from_col``, which returns a ``colander.SchemaNode`` given a
-  ``sqlachemy.schema.Column``
+If the available customisation isn't sufficient, then you can subclass the
+following :class:`colanderalchemy.SQLAlchemySchemaNode` methods when you need
+more control:
 
-* ``get_schema_from_rel``, which returns a ``colander.SchemaNode`` given a
+* :meth:`SQLAlchemySchemaNode.get_schema_from_column`, which
+  returns a ``colander.SchemaNode`` given a ``sqlachemy.schema.Column``
+
+* :meth:`SQLAlchemySchemaNode.get_schema_from_relationship`,
+  which returns a ``colander.SchemaNode`` given a
   ``sqlalchemy.orm.relationship``.
   
 
-Changing auto-generation rules directly in SQLAlchemy models
-============================================================
+.. _info_argument:
 
-You can customize the Colander schema built by ``ColanderAlchemy`` directly
-in the SQLAlchemy models as follow::
+Configuring within SQLAlchemy models
+------------------------------------
 
-    from colanderalchemy import Column
-    from colanderalchemy import relationship
+One of the most useful aspects of ``ColanderAlchemy`` is the ability to
+customize the schema being built by including hints directly in your
+``SQLAlchemy`` models. This means you can define just one ``SQLAlchemy``
+model and have it translate to a fully-customised ``Colander`` schema, and
+do so purely using declarative code.  Alternatively, since the resulting schema
+is just a :class:`colander.SchemaNode`, you can configure it imperatively too,
+if you prefer.
+
+``Colander`` options can be specified declaratively in ``SQLAlchemy`` models
+using the ``info`` argument that you can pass to either
+:class:`sqlalchemy.Column` or :meth:`sqlalchemy.orm.relationship`.  ``info``
+accepts any and all options that :class:`colander.SchemaNode` objects do and
+should be specified like so::
+
+    name = Column('name', info={'colanderalchemy': {'title': 'Your name',
+                                                    'description': 'Test',
+                                                    'missing': 'Anonymous',
+                                                    ...}
+                               })
+
+and you can add any number of other options into the ``dict`` structure as
+described above.  So, anything you want passed to the resulting mapped
+:class`colander.SchemaNode` should be added here.  This also includes
+things like ``widget``, which, whilst not part of ``Colander`` by default, is
+useful for a library like ``Deform``.
+
+A full worked example could be like this::
 
     from sqlalchemy import Integer
     from sqlalchemy import Unicode
@@ -53,54 +89,65 @@ in the SQLAlchemy models as follow::
 
     class Person(Base):
         __tablename__ = 'person'
+        #Fully customised schema node
         id = Column(sqlalchemy.Integer,
                     primary_key=True,
-                    ca_type=colander.Float(),
-                    ca_name='ID',
-                    ca_title='Person ID',
-                    ca_description='The Person identifier.',
-                    ca_widget='Empty Widget',
-                    ca_include=True)
+                    info={'colanderalchemy': {'type': colander.Float(),
+                                              'name': 'ID',
+                                              'title': 'Person ID',
+                                              'description': 'The Person identifier.',
+                                              'widget': 'Empty Widget'}})
+        #Explicitly set as a default field
         name = Column(sqlalchemy.Unicode(128),
                       nullable=False,
-                      ca_nullable=True,
-                      ca_include=True,
-                      ca_default=colander.required)
+                      info={'colanderalchemy': {'default': colander.required}})
+        #Explicitly excluded from resulting schema
         surname = Column(sqlalchemy.Unicode(128),
                          nullable=False,
-                         ca_exclude=True)
+                         info={'colanderalchemy': {'exclude': True}})
+
 
 .. _ca-keyword-arguments:
 
 Customizable Keyword Arguments
-==============================
+------------------------------
 
-``colanderalchemy.Column`` and ``colanderalchemy.relationship`` accept
-following keyword arguments that are mapped directly to attributes on
-``colander.SchemaNode``: 
+``sqlalchemy.Column`` and ``sqlalchemy.orm.relationship`` can be configured
+with an ``info`` argument that ``ColanderAlchemy`` will use to customise
+resulting :class:`colander.SchemaNode` objects for each attribute.  The
+special (magic) key for attributes is ``colanderalchemy``, so a Column definition should look like how it was mentioned above in :ref:`info_argument`.
 
-    * ``ca_type``,
-    * ``ca_children``,
-    * ``ca_default``,
-    * ``ca_missing``,
-    * ``ca_preparer``,
-    * ``ca_validator``,
-    * ``ca_after_bind``,
-    * ``ca_title``, 
-    * ``ca_description``,
-    * ``ca_widget``.
+This means you can customise options like::
 
-As an example, the value of the keyword ``ca_title`` will be passed as the
-keyword argument ``title`` (the string without the leading ``ca_`` prefix)
-when instatiating the ``colander.SchemaNode``. For more information about
-what these options can do, see the `Colander
+    * ``type``,
+    * ``children``,
+    * ``default``,
+    * ``missing``,
+    * ``preparer``,
+    * ``validator``,
+    * ``after_bind``,
+    * ``title``, 
+    * ``description``,
+    * ``widget``.
+
+with ease.  Keep in mind this list above isn't exhaustive and you should
+refer to the complete documentation over at 
+http://docs.pylonsproject.org/projects/colander/en/latest/basics.html.
+
+So, as an example, the value of ``title`` will be passed as the keyword argument
+``title`` when instatiating the ``colander.SchemaNode``. For more information
+about what each of the options can do, see the `Colander
 <http://rtd.pylonsproject.org/projects/colander/>`_ documentation.
 
-In addition you can specify:
+In addition, you can specify the following custom options to control
+what ``ColanderAlchemy`` itself does:
 
-    * ``ca_include``,
-    * ``ca_exclude``,
-    * ``ca_nullable``,
+    * ``exclude`` - Boolean value for whether to exclude a given attribute.
+      Extremely useful for keeping a ``Column`` or ``relationship`` out of
+      a schema.  For instance, an internal field that shouldn't be made
+      available on a ``Deform`` form.
+    * ``children`` - XXX
+    * ``name`` - XXX
+    * ``typ`` - XXX
 
-These options are useful to either include or exclude attributes from
-the resulting ``colander.Schema`` or to make certain nodes nullable.
+

--- a/docs/source/deform.rst
+++ b/docs/source/deform.rst
@@ -3,17 +3,12 @@
 Examples: using ColanderAlchemy with Deform
 ===========================================
 
-``Colander`` options can be specified declaratively in ``SQLAlchemy`` models
-as shown in the code below::
+When using ``ColanderAlchemy``, the resulting ``Colander`` schema will
+reflect the configuration on the mapped class, as shown in the code below::
 
-    from colanderalchemy import Column
-    from colanderalchemy import relationship
-    from colanderalchemy import SQLAlchemyMapping
+    from colanderalchemy import SQLAlchemySchemaNode
 
-    from sqlalchemy import Enum
-    from sqlalchemy import ForeignKey
-    from sqlalchemy import Integer
-    from sqlalchemy import Unicode
+    from sqlalchemy import Enum, ForeignKey, Integer, Unicode
     from sqlalchemy.ext.declarative import declarative_base
 
 
@@ -37,7 +32,7 @@ as shown in the code below::
         phones = relationship('Phone')
 
 
-    person = SQLAlchemyMapping(Person)
+    schema = SQLAlchemySchemaNode(Person)
 
 The resulting schema from the code above is the same as what would
 be produced by constructing the following ``Colander`` schema by hand::
@@ -66,22 +61,27 @@ be produced by constructing the following ``Colander`` schema by hand::
                                       colander.Length(0, 128))
         phones = Phones(missing=[], default=[])
 
-This means that geting a ``Deform`` form to use ``ColanderAlchemy`` is 
-as simple as using any other ``Colander`` schema::
 
-    from colanderalchemy import SQLAlchemyMapping
+Note the various configuration aspects like field length and the like
+will automatically be mapped. This means that geting a ``Deform`` form
+to use ``ColanderAlchemy`` is as simple as using any other ``Colander``
+schema::
+
+    from colanderalchemy import SQLAlchemySchemaNode
     from deform import Form
 
-    # Using Colander
+    # Using Colander requires manually constructing the schema
     # person = Person()
 
-    # Using ColanderAlchemy
-    person = SQLAlchemyMapping(Person)
+    # Using ColanderAlchemy is easy!
+    person = SQLAlchemySchemaNode(Person)
     
     form = Form(person, buttons=('submit',))
 
 Keep in mind that if you want additional control over the resulting
 ``Colander`` schema and nodes produced (such as controlling a node's `title`,
 `description`, `widget` or more), you are able to provide appropriate keyword
-arguments declaratively within the ``SQLAlchemy`` model. For more
-information, see :ref:`customization`.
+arguments declaratively within the ``SQLAlchemy`` model as part of the
+respective ``info`` argument to a :class:`sqlalchemy.Column` or
+:meth:`sqlalchemy.orm.relationship` declaration. For more information, see
+:ref:`customization`.

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -3,13 +3,16 @@
 Examples
 ========
 
+Less boilerplate
+----------------
+
+The best way to illustrate the benefit of using ``ColanderAlchemy`` is to
+show a comparison between the code required to represent ``SQLAlchemy``
+model as a ``Colander`` schema.
+
 Suppose you have these SQLAlchemy mapped classes::
 
-    from sqlalchemy import Column
-    from sqlalchemy import Enum
-    from sqlalchemy import ForeignKey
-    from sqlalchemy import Integer
-    from sqlalchemy import Unicode
+    from sqlalchemy import Column, Enum, ForeignKey, Integer, Unicode
     from sqlalchemy.ext.declarative import declarative_base
     from sqlalchemy.orm import relationship
 
@@ -45,7 +48,7 @@ Suppose you have these SQLAlchemy mapped classes::
         rank = Column(Integer, default=0)
 
 
-The code you need to create the Colander schema for ``Person`` is::
+The code you need to create the Colander schema for ``Person`` would be::
 
     import colander
 
@@ -89,10 +92,17 @@ The code you need to create the Colander schema for ``Person`` is::
 
         person = Person()
 
+By contrast, all you need to obtain the same Colander schema for the ``Person`` mapped class using ``ColanderAlchemy`` is simply::
 
-The code you need to get the same Colander schema for ``Person`` using ColanderAlchemy is::
+    from colanderalchemy import setup_schema
 
-    from colanderalchemy import SQLAlchemyMapping
+    setup_schema(Person)
+    schema = Person.__colanderalchemy__
 
+Or alternatively, you may do this::
 
-    person = SQLAlchemyMapping(Person)
+    from colanderalchemy import SQLAlchemySchemaNode
+
+    schema = SQLAlchemySchemaNode(Person)
+
+As you can see, it's a lot simpler.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,44 +6,106 @@
 ColanderAlchemy
 ===============
 
-`ColanderAlchemy` helps you autogenerating 
+`ColanderAlchemy` helps you to automatically generate
 `Colander <http://http://docs.pylonsproject.org/projects/colander/en/latest/>`_ 
 schemas based on `SQLAlchemy <http://www.sqlalchemy.org/>`_ mapped classes.
 
-`ColanderAlchemy` autogenerates `Colander` schemas following these rules:
-    1) type of the schema is ``colander.MappingSchema``,
-    2) the schema has a ``colander.SchemaNode`` 
-       for each ``sqlalchemy.Column`` in the mapped object:
-        * the type of ``colander.SchemaNode`` 
-          is based on the type of ``sqlalchemy.Column``,
-        * the ``colander.SchemaNode`` use ``validator=colander.OneOf``
-          when the type of ``sqlalchemy.Column`` is ``sqlalchemy.types.Enum``,
+Quick start
+-----------
+
+In order to get started with `ColanderAlchemy`, you can either use
+:meth:`colanderalchemy.setup_schema` to automatically create and attach a
+schema to a mapped class for you, or else you can use
+:class:`colanderalchemy.SQLAlchemySchemaNode` to have more control over the
+auto-generated schema.
+
+To use :meth:`colanderalchemy.setup_schema`, simply pass it a SQLAlchemy mapped
+class:
+
+.. code-block:: python
+
+   from sqlalchemy import Column, Integer, String, Text
+   from sqlalchemy.ext.declarative import declarative_base
+   from colanderalchemy import setup_schema
+   
+   Base = declarative_base()
+
+   class SomeClass(Base):
+       __tablename__ = 'some_table'
+       id = Column(Integer, primary_key=True)
+       name =  Column(String(50))
+       biography =  Column(Text())
+
+   setup_schema(SomeClass)
+   SomeClass.__colanderalchemy__ #A Colander schema for you to use
+
+If you already have a mapped class available, you can just pass it as is - you
+don't need to redefine another schema. Using the given techniques, you can
+associate configuration with your mapped class to tell ``ColanderAlchemy``
+how to generate each and every part of your mapped schema - including things
+like titles, descriptions, preparers, validators, widgets, and more. Check out
+:ref:`info_argument` for more information on how.
+
+Alternatively, if you'd like more control over your generated schema, then
+use :class:`colanderalchemy.SQLAlchemySchemaNode` directly like so:
+
+.. code-block:: python
+
+    from colanderalchemy import SQLAlchemySchemaNode
+    from my.project import SomeClass
+
+    schema = SQLAlchemySchemaNode(SomeClass, includes=['name', 'biography'],
+                                  excludes=['id'], title='Some class') 
+
+Note the various arguments you can pass when creating your mapped schema -
+you have full control over how the schema is generated and what fields
+are included, which are excluded, and more. See the
+:class:`colanderalchemy.SQLAlchemySchemaNode` API documentation for more
+information. For more information you should read the section :ref:`examples`
+to see how use `ColanderAlchemy`.
+
+In either situation, you can now pass the resulting ``Colander`` schema to
+anything that needs it.  For instance, this works well with ``Deform`` and you
+can read more about this later in this documentation: :ref:`deform`.
+
+How it works
+------------
+
+`ColanderAlchemy` auto-generates `Colander` schemas following these rules:
+
+    1) The type of the schema is ``colander.MappingSchema``,
+
+    2) The schema has a ``colander.SchemaNode`` for each ``sqlalchemy.Column``
+       in the mapped object:
+
+        * The type of ``colander.SchemaNode`` 
+          is based on the type of ``sqlalchemy.Column``
+        * The ``colander.SchemaNode`` use ``validator=colander.OneOf``
+          when the type of ``sqlalchemy.Column`` is ``sqlalchemy.types.Enum``
         * ``colander.SchemaNode`` has ``missing=None`` 
-          when the ``sqlalchemy.Column`` has ``nullable=True``,
+          when the ``sqlalchemy.Column`` has ``nullable=True``
         * ``colander.SchemaNode`` has ``missing=colander.required`` 
           when the ``sqlalchemy.Column`` has ``nullable=False`` or 
-          ``primary_key=True``,
+          ``primary_key=True``
         * ``colander.SchemaNode`` has ``missing=VALUE`` and ``default=VALUE`` 
-          when the ``sqlalchemy.Column`` has ``default=VALUE``,
-    3) these schema has a ``colander.SchemaNode`` 
-       for each `relationship` in the mapped object:
-        * the ``colander.SchemaNode`` has ``missing=None``,
-        * the type of ``colander.SchemaNode`` is:
-            * a ``colander.Mapping``
-              for `ManyToOne and OneToOne relationships`,
-            * a ``colander.Sequence`` of ``colander.Mapping``
-              for `ManyToMany and OneToMany relationships`,
-        * for both kind of relationships:
-            * the ``colander.Mapping`` is built using `rule 2` 
-              on the mapped class referenced by relationship.
+          when the ``sqlalchemy.Column`` has ``default=VALUE``
 
+    3) The schema has a ``colander.SchemaNode`` for each `relationship`
+       (``sqlalchemy.orm.relationship`` or those from
+       ``sqlalchemy.orm.backref``) in the mapped object:
 
-Read the section :ref:`customization` to see how change these rules and how to customize
-the Colander schema returned by ColanderAlchemy.
+        * The ``colander.SchemaNode`` has ``missing=None``
+        * The type of ``colander.SchemaNode`` is:
+            * A ``colander.Mapping`` for `ManyToOne and OneToOne
+              relationships`
+            * A ``colander.Sequence`` of ``colander.Mapping`` for `ManyToMany
+              and OneToMany relationships`
 
-Read the section :ref:`examples` to see how use `ColanderAlchemy`.
+        For both kind of relationships, the ``colander.Mapping`` is built using
+        `rule 2` on the mapped class referenced by relationship.
 
-Read the section :ref:`deform` to see how use `ColanderAlchemy` with Deform.
+Read the section :ref:`customization` to see how change these rules and how to
+customize the Colander schema returned by ColanderAlchemy.
 
 Contents
 --------


### PR DESCRIPTION
Documents almost everything.  The only things I couldn't document were `overrides` in both the documentation and the API docs.  If you grep for 'XXX' in the code, you'll see where and what needs documenting.

This also changes the setup-schema function definition to not accept a `mapper` argument -- it wasn't used before, so someone using that function would always need to pass `None` or in fact anything - to be able to use the function.

That should do it!
