### PR TITLE
setup.py broken for py3k

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ version = '0.2'
 setup(name='ColanderAlchemy',
       version=version,
       description="Autogenerate Colander schemas based on SQLAlchemy models.",
-      long_description=open('README.rst', 'rb').read(),
+      long_description=open('README.rst').read(),
       classifiers=['Development Status :: 4 - Alpha',
                    'Intended Audience :: Developers',
                    'Programming Language :: Python',


### PR DESCRIPTION
I get the following exception when trying to install the package in Python 3.3:

Traceback (most recent call last):
  File "setup.py", line 30, in <module>
    test_suite='tests',
  File "/usr/lib/python3.3/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.3/distutils/dist.py", line 917, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.3/distutils/dist.py", line 936, in run_command
    cmd_obj.run()
  File "/sites/tmp/env/lib/python3.3/site-packages/distribute-0.6.28-py3.3.egg/setuptools/command/install.py", line 73, in run
    self.do_egg_install()
  File "/sites/tmp/env/lib/python3.3/site-packages/distribute-0.6.28-py3.3.egg/setuptools/command/install.py", line 93, in do_egg_install
    self.run_command('bdist_egg')
  File "/usr/lib/python3.3/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python3.3/distutils/dist.py", line 936, in run_command
    cmd_obj.run()
  File "/sites/tmp/env/lib/python3.3/site-packages/distribute-0.6.28-py3.3.egg/setuptools/command/bdist_egg.py", line 172, in run
    self.run_command("egg_info")
  File "/usr/lib/python3.3/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python3.3/distutils/dist.py", line 936, in run_command
    cmd_obj.run()
  File "/sites/tmp/env/lib/python3.3/site-packages/distribute-0.6.28-py3.3.egg/setuptools/command/egg_info.py", line 172, in run
    writer(self, ep.name, os.path.join(self.egg_info,ep.name))
  File "/sites/tmp/env/lib/python3.3/site-packages/distribute-0.6.28-py3.3.egg/setuptools/command/egg_info.py", line 384, in write_pkg_info
    metadata.write_pkg_info(cmd.egg_info)
  File "/usr/lib/python3.3/distutils/dist.py", line 1015, in write_pkg_info
    self.write_pkg_file(pkg_info)
  File "/usr/lib/python3.3/distutils/dist.py", line 1036, in write_pkg_file
    long_desc = rfc822_escape(self.get_long_description())
  File "/usr/lib/python3.3/distutils/util.py", line 490, in rfc822_escape
    lines = header.split('\n')
TypeError: Type str doesn't support the buffer API

The description just needs to be loaded in as a plain string instead of a binary string.
