### PR TITLE
Default strategy for column and relationship include should be changed.

### DIFF
--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -183,7 +183,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
         validator = None
 
         # The type of the SchemaNode will be evaluated using the Column type.
-        # User can overridden the default type via Column.info or 
+        # User can overridden the default type via Column.info or
         # imperatively using overrides arg in SQLAlchemySchemaNode.__init__
 
         # Support sqlalchemy.types.TypeDecorator
@@ -236,7 +236,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
 
         # Add default values for missing parameters.
         if column.default is None or not hasattr(column.default, 'arg') or \
-           (isinstance(column_type, Integer) and 
+           (isinstance(column_type, Integer) and
             column.primary_key and column.autoincrement):
             default = None
 
@@ -248,18 +248,18 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
             default = column.default.arg
 
         if not column.nullable and \
-           not (isinstance(column_type, Integer) and 
+           not (isinstance(column_type, Integer) and
                 column.primary_key and column.autoincrement):
             missing = required
 
         elif not column.default is None and column.default.is_callable and \
-                not (isinstance(column_type, Integer) and 
+                not (isinstance(column_type, Integer) and
                      column.primary_key and column.autoincrement):
             # Fix: SQLA wraps default callables in lambda ctx: fn().
             missing = column.default.arg(None)
 
         elif not column.default is None and not column.default.is_callable and \
-                not (isinstance(column_type, Integer) and 
+                not (isinstance(column_type, Integer) and
                      column.primary_key and column.autoincrement):
             missing = column.default.arg
 
@@ -375,9 +375,6 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
         else:
             excludes = None
 
-        if includes is None and excludes is None:
-            includes = [p.key for p in inspect(class_).column_attrs]
-
         key = 'overrides'
         imperative_rel_overrides = overrides.pop(key, None)
         declarative_rel_overrides = declarative_overrides.pop(key, None)
@@ -436,7 +433,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
 
     def dictify(self, obj):
         """ Return a dictified version of `obj` using schema information.
-        
+
         The schema will be used to choose what attributes will be
         included in the returned dict.
 

--- a/tests/bak
+++ b/tests/bak
@@ -1,0 +1,26 @@
+class Cycle(Base):
+
+    __tablename__ = 'cycle'
+
+    id = Column(Integer, primary_key=True)
+    cycle = relationship('CycleChildren')
+    cycle_id = Column(Integer, ForeignKey('cycle_children.id'))
+
+
+class CycleChildren(Base):
+
+    __tablename__ = 'cycle_children'
+
+    id = Column(Integer, primary_key=True)
+    cycle = relationship('CycleChildren2')
+    cycle_id = Column(Integer, ForeignKey('cycle_children2.id'))
+
+
+class CycleChildren2(Base):
+
+    __tablename__ = 'cycle_children2'
+
+    id = Column(Integer, primary_key=True)
+    cycle = relationship('Cycle')
+    cycle_id = Column(Integer, ForeignKey('cycle.id'))
+

--- a/tests/models.py
+++ b/tests/models.py
@@ -96,3 +96,30 @@ class Address(Base):
     longitude = Column(Numeric, nullable=True)
     person_id = Column(Integer, ForeignKey('people.id'))
     person = relationship(Person, info={key: {'exclude': True}})
+
+
+class Cycle(Base):
+
+    __tablename__ = 'cycle'
+
+    id = Column(Integer, primary_key=True)
+    cycle = relationship('CycleChildren')
+    cycle_id = Column(Integer, ForeignKey('cycle_children.id'))
+
+
+class CycleChildren(Base):
+
+    __tablename__ = 'cycle_children'
+
+    id = Column(Integer, primary_key=True)
+    cycle = relationship('CycleChildren2')
+    cycle_id = Column(Integer, ForeignKey('cycle_children2.id'))
+
+
+class CycleChildren2(Base):
+
+    __tablename__ = 'cycle_children2'
+
+    id = Column(Integer, primary_key=True)
+    cycle = relationship('Cycle')
+    cycle_id = Column(Integer, ForeignKey('cycle.id'))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,7 +18,8 @@ from sqlalchemy.orm import (mapper,
 from models import (Account,
                     Person,
                     Address,
-                    Group)
+                    Group,
+                    Cycle)
 import colander
 import logging
 import sys
@@ -378,3 +379,24 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         #Group may have members
         self.assertFalse(schema['members'].required)
         self.assertEqual(schema['members'].missing, [])
+
+    def test_relationship_circular_dependencies(self):
+        """Test to ensure relationship circualar dependencies are handled correctly
+        """
+        # Circuar dependencies excluded by default
+        schema = SQLAlchemySchemaNode(Cycle)
+        self.assertFalse("cycle" in schema["cycle"]["cycle"])
+
+        # Imperatively include circualar dependencies
+        overrides = {
+            'cycle': {
+                'overrides': {
+                    'cycle': {
+                        'includes': ['cycle']
+                    }
+                }
+            }
+        }
+        schema = SQLAlchemySchemaNode(Cycle, overrides=overrides)
+        self.assertTrue("cycle" in schema["cycle"]["cycle"])
+        self.assertTrue("id" in schema["cycle"]["cycle"]["cycle"])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -66,7 +66,7 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             self.assertIn(attr.key, account_schema['person'])
 
         for attr in m.relationships:
-            self.assertNotIn(attr.key, account_schema['person'])
+            self.assertIn(attr.key, account_schema['person'])
 
     def test_imperative_includes(self):
         m = inspect(Account)


### PR DESCRIPTION
Now it's really weird. For the table in first depth, if no includes are specified, all columns and relationships are included, but for all children tables only columns are included. I think behavior must be consistent and that relationships should always be included, or you can still specify in excludes to exclude them. The following two lines are unecessary and are causing problems in my case:

    if includes is None and excludes is None:
        includes = [p.key for p in inspect(class_).column_attrs]