### PR TITLE
added note about callable column default only being called once

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -114,7 +114,9 @@ How it works
           when the ``sqlalchemy.Column`` has ``nullable=False`` or 
           ``primary_key=True``
         * ``colander.SchemaNode`` has ``missing=VALUE`` and ``default=VALUE`` 
-          when the ``sqlalchemy.Column`` has ``default=VALUE``
+          when the ``sqlalchemy.Column`` has ``default=VALUE`` (*Note: a 
+          callable default will only be called **once** when generating the 
+          schema*)
 
     3) The schema has a ``colander.SchemaNode`` for each `relationship`
        (``sqlalchemy.orm.relationship`` or those from


### PR DESCRIPTION
I have a field that defaults to 'datetime.now' and was noticing that the form was consistently using the same value every time the form was rendered.  That makes sense since Colander only accepts a static value, but is surprising if you don't already know that.  I thought it would be prudent to at least add a warning about it in the documents.
