### PR TITLE
only set the __colanderalchemy__ attribute on the sqlalchemy object once

### DIFF
--- a/colanderalchemy/__init__.py
+++ b/colanderalchemy/__init__.py
@@ -34,4 +34,5 @@ def setup_schema(mapper, class_):
         attributes, related mapped classes (via SQLAlchemy relationships)
         and the like.
     """
-    setattr(class_, __colanderalchemy__, SQLAlchemySchemaNode(class_))
+    if not hasattr(class_, __colanderalchemy__):
+        setattr(class_, __colanderalchemy__, SQLAlchemySchemaNode(class_))


### PR DESCRIPTION
I noticed a while ago that `setup_schema` was being called multiple times causing the `SQLAlchemySchemaNode()` to be called multiple times unnecessarily.  I don't completely understand why this is happening, but I modified the method to only add the attribute if it hasn't already been added to stop all the additional calls.

When I run the `test_defaultmissing_primarykey()` I noticed that `setup_schema` was being called 9 times for both `User` and `Widget`.  That happens when the manual call to `SQLAlchemySchemaNode(User)` and `SQLAlchemySchemaNode(Widget)` are made.
