### PR TITLE
Allow setting ColanderAlchemy options in sqlalchemy type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Change Log
   mapping an SQLAlchemy relationship. Previously, overrides were applied
   to both the Sequence and Mapping nodes, leading to unexpected behaviour.
   [davidjb]
+- Allow setting ColanderAlchemy options in sqlalchemy type. [pieterproigia]
 
 
 0.3.1 (2014-03-19)

--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -196,7 +196,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
         key = 'exclude'
 
         if key not in itertools.chain(declarative_overrides, overrides) \
-           and kwargs.pop(key, False):
+           and kwargs.get(key, False):
             log.debug('Column %s skipped due to sqlalchemy type overrides',
                       name)
             return None

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -93,6 +93,26 @@ dict-like structure of options that will be passed to
                                       'validator': address_validator}
         # Other SQLAlchemy columns are defined here
 
+It is also possible to customize the column type, this is done in the same
+manner as above, using the ``__colanderalchemy_config__`` attribute, like so:
+
+.. code:: python
+
+    from sqlalchemy import types
+
+    def email_validator(node, value):
+        # Validate an e-mail address
+        pass
+
+    class Email(types.TypeDecorator):
+
+        impl = types.String
+        
+        __colanderalchemy_config__ = {'validator': email_validator}
+
+It should be noted that the ``default`` and ``missing`` colander options can
+not be set in a SQLAlchemy type.
+
 
 
 Worked example

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,6 +113,8 @@ How it works
           is an instance of either ``sqlalchemy.types.Enum`` or 
           ``sqlalchemy.types.String``.  ``Enum`` is checked with ``colander.OneOf``
           and ``String`` is checked with ``colander.Length``
+        * Customization stored in the ``__colanderalchemy_config__`` attribute of the
+          SQLAlchemy type are applied.
         * ``colander.SchemaNode`` has ``missing=colander.required`` except for
           the when ``default`` is set, ``nullable=True``, there's a ``server_default``,
           or the field is an auto incrementing integer used as part of a primary key.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1022,6 +1022,33 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         self.is_equal_schema(schema, schema2)
 
 
+    def test_validator_type_override(self):
+        Base = declarative_base()
+
+        def location_validator(value, node):
+            """A dummy validator."""
+            pass
+
+        class LocationEnum(TypeDecorator):
+            impl = Enum
+            __colanderalchemy_config__ = {'validator': location_validator}
+
+        class LocationString(TypeDecorator):
+            impl = String
+            __colanderalchemy_config__ = {'validator': location_validator}
+
+        class House(Base):
+            __tablename__ = 'house'
+            id = Column(Integer, primary_key=True)
+            door = Column(LocationEnum(['back', 'front']))
+            window = Column(LocationString(128))
+
+        schema = SQLAlchemySchemaNode(House)
+
+        self.assertEqual(schema['door'].validator, location_validator)
+        self.assertEqual(schema['window'].validator, location_validator)
+
+
     def test_type_override_name(self):
         Base = declarative_base()
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1020,3 +1020,18 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         schema2 = generate_colander()
 
         self.is_equal_schema(schema, schema2)
+
+
+    def test_type_override_name(self):
+        Base = declarative_base()
+
+        class WrongType(TypeDecorator):
+            impl = String
+            __colanderalchemy_config__ = {'name': 'Wrong!'}
+
+        class BadTable(Base):
+            __tablename__ = 'badtable'
+            nasty_column = Column(WrongType, primary_key=True)
+
+        self.assertRaises(ValueError, SQLAlchemySchemaNode, BadTable,
+            None, None, None)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1049,6 +1049,25 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         self.assertEqual(schema['window'].validator, location_validator)
 
 
+    def test_default_type_override(self):
+        Base = declarative_base()
+
+        class MyInt(TypeDecorator):
+            impl = Integer
+            __colanderalchemy_config__ = {'default': 42}
+
+        class Numbers(Base):
+            __tablename__ = 'numbers'
+            id = Column(Integer, primary_key=True)
+            number1 = Column(MyInt)
+            number2 = Column(MyInt, default=0)
+
+        schema = SQLAlchemySchemaNode(Numbers)
+
+        self.assertEqual(schema['number1'].default, 42)
+        self.assertEqual(schema['number2'].default, 0)
+
+
     def test_type_override_name(self):
         Base = declarative_base()
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1072,6 +1072,31 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         except AttributeError:
             pass
 
+    def test_missing_typedecorator_override(self):
+        Base = declarative_base()
+
+        class MyInt(TypeDecorator):
+            impl = Integer
+            __colanderalchemy_config__ = {'missing': 42}
+
+        class Numbers(Base):
+            __tablename__ = 'numbers'
+            id = Column(Integer, primary_key=True)
+            number1 = Column(MyInt)
+
+        self.assertRaises(ValueError, SQLAlchemySchemaNode, Numbers,
+            None, None, None)
+
+        """ SQLAlchemy gives sqlalchemy.exc.InvalidRequestError errors for
+            subsequent tests because this mapper is not always garbage
+            collected quick enough.  By removing the _configured_failed
+            flag on the mapper this allows later tests to function
+            properly.
+        """
+        try:
+            del Numbers.__mapper__._configure_failed
+        except AttributeError:
+            pass
 
 
     def test_typedecorator_override_name(self):


### PR DESCRIPTION
This allows for an extra location for customization of the schema inside a `column.type`. It looks for the `__colanderalchemy_config__` attribute in the type for customization. This allows for:

```Python
import colander
from sqlalchemy import Column, Integer, Unicode
from sqlalchemy.type import TypeDecorator
from sqlalchemy.ext.declarative import declarative_base

Base = declarative_base()

class Email(TypeDecorator):
    impl = Unicode
    __colanderalchemy_config__ = {'validator': colander.Email}

class User(Base):
    __tablename__ = 'user'
    id = Column(Integer, primary_key=True)
    email = Column(Email, nullable=False)
    second_email = Column(Email)

schema = SQLAlchemySchemaNode(User)

```
Being equal to the following colander schema:
```Python
import colander

class User(colander.MappingSchema):
    id = colander.SchemaNode(colander.Integer(),
                             missing=colander.drop)
    email = colander.SchemaNode(colander.String(),
                                validator=colander.Email())
    second_email = colander.SchemaNode(colander.String(),
                                       validator=colander.Email(),
                                       missing=colander.drop)
```

Where both email columns will be validated with `colander.Email`, but `email` will have missing required and `second_email` missing drop in the colander schema.