### PR TITLE
make version PEP440 compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-version = '0.3.2dev'
+version = '0.3.2.dev1'
 
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()


### PR DESCRIPTION
setuptools complains about the version number not being PEP440 compliant
