### PR TITLE
Add custom column in includes and fixes #45 and some pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   - 3.4
   - pypy3
 
-#install: python setup.py develop  # install doesn't seem to be needed for testing
+install:
+    - pip install deform
 
 script: python setup.py test -q

--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -6,12 +6,10 @@
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
 from colander import (Mapping,
-                      null,
                       drop,
                       required,
                       SchemaNode,
                       Sequence)
-from inspect import isfunction
 from sqlalchemy import (Boolean,
                         Date,
                         DateTime,
@@ -35,7 +33,7 @@ log = logging.getLogger(__name__)
 
 def _creation_order(obj):
     """
-    Used for sorting SQLAlchemy attributes in the order that 
+    Used for sorting SQLAlchemy attributes in the order that
     they were defined
     """
     if isinstance(obj, ColumnProperty):
@@ -45,6 +43,7 @@ def _creation_order(obj):
 
 
 class SQLAlchemySchemaNode(colander.SchemaNode):
+
     """ Build a Colander Schema based on the SQLAlchemy mapped class.
     """
 
@@ -106,7 +105,6 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
            See http://docs.pylonsproject.org/projects/colander/en/latest/basics.html for more information.
         """
 
-
         self.inspector = inspect(class_)
         kwargs = kw.copy()
 
@@ -126,43 +124,43 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
 
     def add_nodes(self, includes, excludes, overrides):
 
-        # sorted to maintain the order in which the attributes
-        # are defined
-        for prop in sorted(self.inspector.attrs, key=_creation_order):
+        if set(excludes) & set(includes):
+            msg = 'excludes and includes are mutually exclusive.'
+            raise ValueError(msg)
 
-            name = prop.key
+        properties = sorted(self.inspector.attrs, key=_creation_order)
 
-            if name in excludes and name in includes:
-                msg = 'excludes and includes are mutually exclusive.'
-                raise ValueError(msg)
+        for name in includes or [item.key for item in properties]:
+            prop = self.inspector.attrs.get(name, name)
 
             if name in excludes or (includes and name not in includes):
                 log.debug('Attribute %s skipped imperatively', name)
                 continue
-            
-            name_overrides_copy = overrides.get(name,{}).copy()
+
+            name_overrides_copy = overrides.get(name, {}).copy()
 
             if isinstance(prop, ColumnProperty):
                 node = self.get_schema_from_column(
-                    prop, 
+                    prop,
                     name_overrides_copy
                 )
             elif isinstance(prop, RelationshipProperty):
                 node = self.get_schema_from_relationship(
-                    prop, 
+                    prop,
                     name_overrides_copy
                 )
+            elif isinstance(prop, colander.SchemaNode):
+                node = prop
             else:
                 log.debug(
                     'Attribute %s skipped due to not being '
-                    'a ColumnProperty or RelationshipProperty', 
+                    'a ColumnProperty or RelationshipProperty',
                     name
                 )
                 continue
-                
+
             if node is not None:
                 self.add(node)
-
 
     def get_schema_from_column(self, prop, overrides):
         """ Build and return a :class:`colander.SchemaNode` for a given Column.
@@ -207,7 +205,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
         children = []
 
         # The type of the SchemaNode will be evaluated using the Column type.
-        # User can overridden the default type via Column.info or 
+        # User can overridden the default type via Column.info or
         # imperatively using overrides arg in SQLAlchemySchemaNode.__init__
 
         # Support sqlalchemy.types.TypeDecorator
@@ -221,16 +219,16 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
                 type_ = imperative_type()
             else:
                 type_ = imperative_type
-            log.debug('Column %s: type overridden imperatively: %s.', 
-                        name, type_)
+            log.debug('Column %s: type overridden imperatively: %s.',
+                      name, type_)
 
         elif declarative_type is not None:
             if hasattr(declarative_type, '__call__'):
                 type_ = declarative_type()
             else:
                 type_ = declarative_type
-            log.debug('Column %s: type overridden via declarative: %s.', 
-                        name, type_)
+            log.debug('Column %s: type overridden via declarative: %s.',
+                      name, type_)
 
         elif isinstance(column_type, Boolean):
             type_ = colander.Boolean()
@@ -266,7 +264,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
 
         """
         Add default values
-        
+
         possible values for default in SQLA:
          1. plain non-callable Python value
               - give to Colander as a default
@@ -275,8 +273,8 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
          3. Python callable with 0 or 1 args
             1 arg version takes ExecutionContext
               - leave default blank and allow SQLA to fill
-              
-        all values for server_default should be ignored for 
+
+        all values for server_default should be ignored for
         Colander default
         """
         if isinstance(column.default, ColumnDefault) and column.default.is_scalar:
@@ -284,7 +282,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
 
         """
         Add missing values
-        
+
         possible values for default in SQLA:
          1. plain non-callable Python value
               - give to Colander as a missing unless nullable
@@ -294,30 +292,29 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
          3. Python callable with 0 or 1 args
             1 arg version takes ExecutionContext
               - call function to get value for missing [ <- should this be changed to missing = drop ]
-        
+
         if nullable, then allowing missing = drop
-        
-        all values for server_default should result in 'drop' 
+
+        all values for server_default should result in 'drop'
         for Colander missing
-        
+
         autoincrement results in drop
         """
         if isinstance(column.default, ColumnDefault):
             if column.default.is_callable:
                 kwargs["missing"] = drop
-            elif column.default.is_clause_element: # SQL expression
+            elif column.default.is_clause_element:  # SQL expression
                 kwargs["missing"] = drop
             elif column.default.is_scalar:
                 kwargs["missing"] = column.default.arg
         elif column.nullable:
             kwargs["missing"] = drop
         elif isinstance(column.server_default, FetchedValue):
-            kwargs["missing"] = drop # value generated by SQLA backend
+            kwargs["missing"] = drop  # value generated by SQLA backend
         elif hasattr(column.table, "_autoincrement_column") and id(column.table._autoincrement_column) == id(column):
             # this column is the autoincrement column, so we can drop
             # it if it's missing and let the database generate it
             kwargs["missing"] = drop
-
 
         kwargs.update(declarative_overrides)
         kwargs.update(overrides)
@@ -458,10 +455,10 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
 
         # Add default values for missing parameters.
         if prop.innerjoin:
-            #Inner joined relationships imply it is mandatory
+            # Inner joined relationships imply it is mandatory
             missing = required
         else:
-            #Any other join is thus optional
+            # Any other join is thus optional
             missing = drop
         kwargs['missing'] = missing
 
@@ -492,7 +489,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
 
     def dictify(self, obj):
         """ Return a dictified version of `obj` using schema information.
-        
+
         The schema will be used to choose what attributes will be
         included in the returned dict.
 
@@ -573,7 +570,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
             attributes.
 
             This is a perfect fit for something like a CRUD environment.
-            
+
             Default: ``None``.  Defaults to instantiating a new instance of the
             mapped class associated with this schema.
         """
@@ -585,7 +582,6 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
                 value = dict_[attr]
                 # Convert value into objects if property has a mapper
                 if hasattr(prop, 'mapper'):
-                    cls = prop.mapper.class_
                     if prop.uselist:
                         # Sequence of objects
                         value = [self[attr].children[0].objectify(obj)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,7 +39,7 @@ definitions.
 By associating ``ColanderAlchemy`` configuration with your mapped class,
 its columns, and its relationships, you can tell ``ColanderAlchemy``
 how to generate each and every part of your mapped schema - including things
-like titles, descriptions, preparers, validators, widgets, and more. 
+like titles, descriptions, preparers, validators, widgets, and more.
 
 Check out :ref:`info_argument` for more information on how.
 
@@ -68,7 +68,7 @@ mapped class like so:
    SomeClass.__colanderalchemy__ #A Colander schema for you to use
 
 If you already have a mapped class available, you can just pass it as is - you
-don't need to redefine another schema. 
+don't need to redefine another schema.
 
 Also, if you'd like even more control over your generated schema, then
 use :class:`colanderalchemy.SQLAlchemySchemaNode` directly like so:
@@ -81,7 +81,28 @@ use :class:`colanderalchemy.SQLAlchemySchemaNode` directly like so:
     schema = SQLAlchemySchemaNode(SomeClass,
                                   includes=['name', 'biography'],
                                   excludes=['id'],
-                                  title='Some class') 
+                                  title='Some class')
+
+Or include custom field:
+
+.. code-block:: python
+
+    import deform
+    import colander
+    from colanderalchemy import SQLAlchemySchemaNode
+    from my.project import SomeClass
+
+    typ = colander.String()
+    widget = deform.widget.SelectWidget(values=(('foo', 'a'),
+                                                ('bar', 'b'),
+                                                ('baz', 'c')))
+    column = colander.SchemaNode(typ,
+                                 name='customfield',
+                                 widget=widget)
+    schema = SQLAlchemySchemaNode(SomeClass,
+                                  includes=['name', column, 'biography'],
+                                  excludes=['id'],
+                                  title='Some class')
 
 Note the various arguments you can pass when creating your mapped schema -
 you have full control over how the schema is generated and what fields

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,39 +5,23 @@
 # This module is part of ColanderAlchemy and is released under
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
-from colanderalchemy import (setup_schema,
-                             SQLAlchemySchemaNode)
-from sqlalchemy import (Column,
-                        event,
-                        ForeignKey,
-                        Unicode,
-                        Integer,
-                        BigInteger,
-                        TIMESTAMP,
-                        String,
-                        Enum)
-import sqlalchemy
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.ext.hybrid import (hybrid_property,
-                                   hybrid_method)
-from sqlalchemy.orm import (mapper,
-                            relationship,
-                            synonym,
-                            aliased)
-from sqlalchemy.sql.expression import (text, 
-                                       func,
-                                       true,
-                                       false)
-from sqlalchemy.schema import DefaultClause
-from tests.models import (Account,
-                          Person,
-                          Address,
-                          Group,
-                          has_unique_addresses)
-import colander
 import datetime
 import logging
 import sys
+
+import colander
+import deform
+import sqlalchemy
+from sqlalchemy import (BigInteger, Column, Enum, ForeignKey, Integer, String,
+                        TIMESTAMP, Unicode)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
+from sqlalchemy.orm import aliased, relationship, synonym
+from sqlalchemy.schema import DefaultClause
+from sqlalchemy.sql.expression import func, text
+
+from colanderalchemy import SQLAlchemySchemaNode
+from tests.models import Account, Address, Group, has_unique_addresses, Person
 
 if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     # In Python < 2.7 use unittest2.
@@ -54,29 +38,24 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
     def setUp(self):
         pass
 
-
     def tearDown(self):
         pass
-
 
     def test_setup_schema(self):
         for cls in [Account, Person, Address]:
             self.assertIsInstance(cls.__colanderalchemy__,
                                   SQLAlchemySchemaNode)
 
-
     def test_add_nodes_exceptions(self):
         includes = ('email',)
         excludes = ('email',)
         self.assertRaises(ValueError, SQLAlchemySchemaNode, Account, includes, excludes)
-
 
     def test_default_strategy_for_columns_and_relationships_include_all(self):
         account_schema = SQLAlchemySchemaNode(Account)
         m = sqlalchemy.inspect(Account)
         for attr in m.attrs:
             self.assertIn(attr.key, account_schema)
-
 
     def test_default_strategy_for_included_relationships_schema(self):
         account_schema = SQLAlchemySchemaNode(Account)
@@ -86,7 +65,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
 
         for attr in m.relationships:
             self.assertNotIn(attr.key, account_schema['person'])
-
 
     def test_imperative_includes(self):
         m = sqlalchemy.inspect(Account)
@@ -106,7 +84,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         for attr in m.relationships:
             self.assertIn(attr.key, account_schema)
 
-
     def test_imperative_excludes(self):
         m = sqlalchemy.inspect(Account)
         excludes = [attr.key for attr in m.column_attrs]
@@ -117,7 +94,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         for attr in m.relationships:
             self.assertIn(attr.key, account_schema)
 
-
     def test_declarative_excludes(self):
         m = sqlalchemy.inspect(Address)
         address_schema = SQLAlchemySchemaNode(Address)
@@ -126,7 +102,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         for attr in m.attrs:
             if attr.key not in ('city', 'person'):
                 self.assertIn(attr.key, address_schema)
-
 
     def test_imperative_colums_overrides(self):
         overrides = {
@@ -143,8 +118,8 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
                 'name': 'Name'
             }
         }
-        self.assertRaises(ValueError, SQLAlchemySchemaNode, Account, 
-            None, None, overrides)
+        self.assertRaises(ValueError, SQLAlchemySchemaNode, Account,
+                          None, None, overrides)
 
         overrides = {
             'email': {
@@ -153,7 +128,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         }
         # following shouldn't raise an exception allowing the test to pass
         SQLAlchemySchemaNode(Account, None, None, overrides)
-
 
     def test_declarative_colums_overrides(self):
         key = SQLAlchemySchemaNode.sqla_info_key
@@ -175,7 +149,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             del WrongColumnOverrides.__mapper__._configure_failed
         except AttributeError:
             pass
-
 
     def test_imperative_relationships_overrides(self):
         overrides = {
@@ -235,7 +208,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         schema = SQLAlchemySchemaNode(Person, overrides=overrides)
         self.assertTrue(isinstance(schema['addresses'].children[0]['id'].typ, colander.String))
 
-
     def test_declarative_relationships_overrides(self):
         key = SQLAlchemySchemaNode.sqla_info_key
         Base = declarative_base()
@@ -245,22 +217,16 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             name = Column(Unicode(32), primary_key=True)
             description = Column(Unicode(128))
 
-        #Fake model to avoid a race condition
-        dummy = Model()
-
         class WrongOverrides(Base):
             __tablename__ = 'WrongOverrides'
             name = Column(Unicode(32), primary_key=True)
             model_id = Column(Unicode(32), ForeignKey('models.name'))
             model = relationship(Model,
                                  info={
-                                    key: {
-                                        'children': [],
-                                    }
-                                })
-
-        #Fake model to avoid a race condition
-        dummy2 = WrongOverrides()
+                                     key: {
+                                         'children': [],
+                                     }
+                                 })
 
         schema = SQLAlchemySchemaNode(WrongOverrides)
         self.assertEqual(schema['model'].children, [])
@@ -271,13 +237,10 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             model_id = Column(Unicode(32), ForeignKey('models.name'))
             model = relationship(Model,
                                  info={
-                                    key: {
-                                        'includes': ['name']
-                                    }
-                                })
-
-        #Fake model to avoid a race condition
-        dummy3 = IncludesOverrides()
+                                     key: {
+                                         'includes': ['name']
+                                     }
+                                 })
 
         schema = SQLAlchemySchemaNode(IncludesOverrides)
         self.assertEqual(set([node.name for node in schema['model']]), set(['name']))
@@ -288,10 +251,10 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             model_id = Column(Unicode(32), ForeignKey('models.name'))
             model = relationship(Model,
                                  info={
-                                    key: {
-                                        'excludes': ['name']
-                                    }
-                                })
+                                     key: {
+                                         'excludes': ['name']
+                                     }
+                                 })
         schema = SQLAlchemySchemaNode(ExcludesOverrides)
         self.assertNotIn('name', schema['model'])
 
@@ -301,16 +264,15 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             model_id = Column(Unicode(32), ForeignKey('models.name'))
             model = relationship(Model,
                                  info={
-                                    key: {
-                                        'children': [],
-                                    }
-                                }, uselist=True)
+                                     key: {
+                                         'children': [],
+                                     }
+                                 }, uselist=True)
         schema = SQLAlchemySchemaNode(UseListOverrides)
         self.assertTrue(isinstance(schema['model'].typ, colander.Sequence))
         # Retrieve and check overrides kwarg.
         schema = SQLAlchemySchemaNode(Person)
         self.assertTrue(isinstance(schema['addresses'].children[0]['id'].typ, colander.Float))
-
 
     def _prep_schema(self):
         overrides = {
@@ -330,10 +292,9 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         }
         includes = ['email', 'enabled', 'created', 'timeout', 'person']
         schema = SQLAlchemySchemaNode(Account, includes=includes, overrides=overrides)
-        #Add a non-SQLAlchemy field
+        # Add a non-SQLAlchemy field
         schema.add(colander.SchemaNode(colander.String(), name='non_sql', missing=colander.drop))
         return schema
-
 
     def test_dictify(self):
         """ Test SQLAlchemySchemaNode.dictify(obj)
@@ -342,20 +303,20 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
 
         address_args = dict(street='My Street', city='My City')
         address = Address(**address_args)
-        
-        person_args = dict(name='My Name', surname='My Surname', 
+
+        person_args = dict(name='My Name', surname='My Surname',
                            gender='M', addresses=[address])
         person = Person(**person_args)
-        
+
         account_args = dict(email='mailbox@domain.tld',
-                      enabled=True,
-                      created=datetime.datetime.now(),
-                      timeout=datetime.time(hour=1, minute=0),
-                      person=person)
+                            enabled=True,
+                            created=datetime.datetime.now(),
+                            timeout=datetime.time(hour=1, minute=0),
+                            person=person)
         account = Account(**account_args)
-        
+
         appstruct = schema.dictify(account)
-        
+
         person_args['addresses'] = [address_args]
         account_args['person'] = person_args
         self.assertEqual(appstruct, account_args)
@@ -367,20 +328,19 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
                     if person_key == 'addresses':
                         for address_key in address_args:
                             self.assertIn(address_key, appstruct[account_key][person_key][0])
-        
+
         # test that you can serialize this appstruct and you get
-        #  the same result when you deserialize
+        # the same result when you deserialize
         cstruct = schema.serialize(appstruct=appstruct)
         newappstruct = schema.deserialize(cstruct)
         self.assertEqual(appstruct, newappstruct)
-
 
     def test_dictify_with_null(self):
         """ Test SQLAlchemySchemaNode.dictify(obj) with null values
         and show that result is a valid appstruct for the given schema
         """
         Base = declarative_base()
-        
+
         class Sensor(Base):
             __tablename__ = 'sensor'
             sensor_id = Column(Integer, primary_key=True)
@@ -388,22 +348,21 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             sensor_label = Column(String, nullable=True)
 
         sensor = Sensor(
-            sensor_id = 3, 
-            institution_id = None, 
-            sensor_label = None,
+            sensor_id=3,
+            institution_id=None,
+            sensor_label=None,
         )
-        
+
         schema = SQLAlchemySchemaNode(Sensor)
         appstruct = schema.dictify(sensor)
         cstruct = schema.serialize(appstruct=appstruct)
         newappstruct = schema.deserialize(cstruct)
         newobj = schema.objectify(appstruct)
-        
+
         self.assertEqual(appstruct, newappstruct)
         self.assertEqual(sensor.sensor_id, newobj.sensor_id)
         self.assertEqual(sensor.institution_id, newobj.institution_id)
         self.assertEqual(sensor.sensor_label, newobj.sensor_label)
-        
 
     def test_objectify(self):
         """ Test converting a dictionary or data structure into objects.
@@ -417,8 +376,8 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
                  'email': 'mailbox@domain.tld',
                  'timeout': datetime.time(hour=0, minute=0),
                  'created': datetime.datetime.now(),
-                 'foobar': 'a fake value' #Not present in schema
-                }
+                 'foobar': 'a fake value'  # Not present in schema
+                 }
         schema = self._prep_schema()
 
         objectified = schema.objectify(dict_)
@@ -427,7 +386,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         self.assertIsInstance(objectified.person, Person)
         self.assertEqual(objectified.person.name, 'My Name')
         self.assertFalse(hasattr(objectified, 'foobar'))
-
 
     def test_objectify_context(self):
         """ Test converting a data structure into objects, using a context.
@@ -443,12 +401,11 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
 
         objectified = schema.objectify(dict_, context=context)
 
-        #Must be the same object
+        # Must be the same object
         self.assertTrue(context is objectified)
         self.assertEqual(objectified.enabled, True)
         self.assertEqual(objectified.email, 'mailbox@domain.tld')
         self.assertEqual(objectified.dummy_property, 'dummy')
-
 
     def test_clone(self):
         schema = SQLAlchemySchemaNode(Account, dummy='dummy', dummy2='dummy2')
@@ -459,7 +416,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
 
         self.assertEqual([node.name for node in schema.children],
                          [node.name for node in cloned.children])
-
 
     def test_schemanode_arguments(self):
         """ Test that any arguments to SchemaNode are accepted.
@@ -472,17 +428,15 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         self.assertEqual(schema.title, 'Dummy')
         self.assertEqual(schema.non_standard, 'Not a Colander arg')
 
-
     def test_read_mapping_configuration(self):
         """ Test using ``__colanderalchemy_config__`` for a mapped class.
         """
         schema = SQLAlchemySchemaNode(Account)
         self.assertEqual(schema.preparer, 'DummyPreparer')
 
-        #Related models will be configured as well
+        # Related models will be configured as well
         self.assertEqual(schema['person'].widget, 'DummyWidget')
         self.assertEqual(schema['person'].title, 'Person Object')
-
 
     def test_missing_mapping_configuration(self):
         """ Test to check ``missing`` is set to an SQLAlchemy-suitable value.
@@ -495,7 +449,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         self.assertNotIn('person_id', deserialized)
         self.assertNotIn('person', deserialized)
 
-
     def test_relationship_mapping_configuration(self):
         """Test to ensure ``missing`` is set to required accordingly.
         """
@@ -503,15 +456,15 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         self.assertTrue(schema.required)
         self.assertEqual(schema.missing, colander.required)
 
-        #Group must have a leader
+        # Group must have a leader
         self.assertTrue(schema['leader'].required)
         self.assertEqual(schema['leader'].missing, colander.required)
 
-        #Group must have an executive
+        # Group must have an executive
         self.assertTrue(schema['executive'].required)
         self.assertEqual(schema['executive'].missing, colander.required)
 
-        #Group may have members
+        # Group may have members
         self.assertFalse(schema['members'].required)
         self.assertEqual(schema['members'].missing, colander.drop)
 
@@ -544,9 +497,10 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         """Ensure proper handling of empty values on primary keys
         """
         Base = declarative_base()
+
         class User(Base):
             __tablename__ = 'user'
-            id = Column(Integer, primary_key=True) # is automatically made autoincrement=True
+            id = Column(Integer, primary_key=True)  # is automatically made autoincrement=True
 
         schema = SQLAlchemySchemaNode(User)
 
@@ -564,19 +518,18 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         class Widget(Base):
             __tablename__ = 'widget'
             id = Column(String, primary_key=True)
-        
+
         schema = SQLAlchemySchemaNode(Widget)
-        
+
         # from <FORM> result into SQLA; tests missing
         self.assertEqual(schema['id'].missing, colander.required)
         self.assertRaises(colander.Invalid, schema.deserialize, {})
-        
+
         # from SQLA result into <FORM>; tests default
         self.assertEqual(schema['id'].default, colander.null)
         serialized = schema.serialize({})
         self.assertIn('id', serialized)
         self.assertEqual(serialized['id'], colander.null)
-
 
     def test_default_clause(self):
         """Test proper handling of default and server_default values
@@ -599,7 +552,7 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         schema = SQLAlchemySchemaNode(Patient)
 
         '''
-        Conceivably you should be able to test DefaultClause for a 
+        Conceivably you should be able to test DefaultClause for a
         scalar type value and use it as a default/missing in Colander.
         However, the value is interpreted by the backend engine and
         it could be interpreted by it in an unexpected way.  For this
@@ -635,15 +588,14 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         self.assertIn('pyfunc_test', serialized)
         self.assertEqual(serialized['pyfunc_test'], colander.null)
 
-
     def test_unsupported_column_types(self):
         """
         Issue #35 - ColanderAlchemy throws when encountering synonyms
-        
+
         ColanderAlchemy should ignore synonyms
         """
         Base = declarative_base()
-        
+
         # example taken from SQLAlchemy docs
         class MyClass(Base):
             __tablename__ = 'my_table'
@@ -675,8 +627,8 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             _child_table = aliased(_parent_table)
 
             __mapper_args__ = {
-                'primary_key': [_child_table.c.id,],
-                'include_properties': [_child_table.c.id,],
+                'primary_key': [_child_table.c.id, ],
+                'include_properties': [_child_table.c.id, ],
             }
 
             __table__ = _parent_table.join(_child_table, _child_table.c.parent_id == _parent_table.c.id)
@@ -690,9 +642,9 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         class Interval(Base):
             __tablename__ = 'interval'
 
-            id = Column(Integer, primary_key=True, info={'id':'id'})
-            start = Column(Integer, nullable=False, info={'start':'start'})
-            end = Column(Integer, nullable=False, info={'end':'end'})
+            id = Column(Integer, primary_key=True, info={'id': 'id'})
+            start = Column(Integer, nullable=False, info={'start': 'start'})
+            end = Column(Integer, nullable=False, info={'end': 'end'})
 
             def __init__(self, start, end):
                 self.start = start
@@ -709,21 +661,19 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             @hybrid_method
             def intersects(self, other):
                 return self.contains(other.start) | self.contains(other.end)
-                
+
             @length.setter
             def length(self, value):
                 self.end = self.start + value
-        
-        
+
         schema = SQLAlchemySchemaNode(Interval)
-        
+
         self.assertIn('id', schema)
         self.assertIn('start', schema)
         self.assertIn('end', schema)
         self.assertNotIn('length', schema)
         self.assertNotIn('contains', schema)
         self.assertNotIn('intersects', schema)
-
 
     def test_doc_example_deform(self):
         """
@@ -732,14 +682,12 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         """
         Base = declarative_base()
 
-
         class Phone(Base):
             __tablename__ = 'phones'
 
             person_id = Column(Integer, ForeignKey('persons.id'), primary_key=True)
             number = Column(Unicode(128), primary_key=True)
             location = Column(Enum('home', 'work'))
-
 
         class Person(Base):
             __tablename__ = 'persons'
@@ -748,11 +696,9 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             name = Column(Unicode(128), nullable=False)
             surname = Column(Unicode(128), nullable=False)
             phones = relationship(Phone)
-        
-        
+
         schema = SQLAlchemySchemaNode(Person)
-        
-        
+
         # because of naming clashes, we need to do this in another function
         def generate_colander():
             class Phone(colander.MappingSchema):
@@ -763,10 +709,8 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
                                                validator=colander.OneOf(['home', 'work']),
                                                missing=colander.drop)
 
-
             class Phones(colander.SequenceSchema):
                 phones = Phone(missing=colander.drop)
-
 
             class Person(colander.MappingSchema):
                 id = colander.SchemaNode(colander.Int(), missing=colander.drop)
@@ -775,14 +719,10 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
                 surname = colander.SchemaNode(colander.String(),
                                               validator=colander.Length(0, 128))
                 phones = Phones(missing=colander.drop)
-                
-            
             return Person()
-        
-        schema2 = generate_colander()
-        
-        self.is_equal_schema(schema, schema2)
 
+        schema2 = generate_colander()
+        self.is_equal_schema(schema, schema2)
 
     def test_doc_example_less_boilerplate(self):
         """
@@ -790,8 +730,6 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         found in docs/source/examples.rst
         """
         Base = declarative_base()
-
-
 
         class Phone(Base):
             __tablename__ = 'phones'
@@ -806,7 +744,7 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             person_id = Column(Integer, ForeignKey('persons.id'), primary_key=True)
             friend_of = Column(Integer, ForeignKey('persons.id'), primary_key=True)
             rank = Column(Integer, default=0)
-        
+
         class Person(Base):
             __tablename__ = 'persons'
 
@@ -820,16 +758,14 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
 
         schema = SQLAlchemySchemaNode(Person)
 
-
         # because of naming clashes, we need to do this in another function
         def generate_colander():
             class Friend(colander.MappingSchema):
                 person_id = colander.SchemaNode(colander.Int())
                 friend_of = colander.SchemaNode(colander.Int())
-                rank = colander.SchemaNode(colander.Int(), 
-                                           missing=0, 
+                rank = colander.SchemaNode(colander.Int(),
+                                           missing=0,
                                            default=0)
-
 
             class Phone(colander.MappingSchema):
                 person_id = colander.SchemaNode(colander.Int())
@@ -839,14 +775,11 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
                                                validator=colander.OneOf(['home', 'work']),
                                                missing=colander.drop)
 
-
             class Friends(colander.SequenceSchema):
                 friends = Friend(missing=colander.drop)
 
-
             class Phones(colander.SequenceSchema):
                 phones = Phone(missing=colander.drop)
-
 
             class Person(colander.MappingSchema):
                 id = colander.SchemaNode(colander.Int(),
@@ -858,43 +791,38 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
                 gender = colander.SchemaNode(colander.String(),
                                              validator=colander.OneOf(['M', 'F']),
                                              missing=colander.drop)
-                age = colander.SchemaNode(colander.Int(), 
+                age = colander.SchemaNode(colander.Int(),
                                           missing=colander.drop)
                 phones = Phones(missing=colander.drop)
                 friends = Friends(missing=colander.drop)
 
-
             return Person()
 
-
         schema2 = generate_colander()
-        
         self.is_equal_schema(schema, schema2)
-
 
     def test_doc_example_Configuring_within_SQLAlchemy(self):
         """
         Test 'Configuring within SQLAlchemy models' example
         found in docs/source/customization.rst
         """
-        
-        Base = declarative_base()
 
+        Base = declarative_base()
 
         class Person(Base):
             __tablename__ = 'person'
-            #Fully customised schema node
+            # Fully customised schema node
             id = Column(sqlalchemy.Integer,
                         primary_key=True,
                         info={'colanderalchemy': {'typ': colander.Float(),
                                                   'title': 'Person ID',
                                                   'description': 'The Person identifier.',
                                                   'widget': 'Empty Widget'}})
-            #Explicitly set as a default field
+            # Explicitly set as a default field
             name = Column(sqlalchemy.Unicode(128),
                           nullable=False,
                           info={'colanderalchemy': {'default': colander.required}})
-            #Explicitly excluded from resulting schema
+            # Explicitly excluded from resulting schema
             surname = Column(sqlalchemy.Unicode(128),
                              nullable=False,
                              info={'colanderalchemy': {'exclude': True}})
@@ -916,19 +844,17 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
             return Person()
 
         schema2 = generate_colander()
-        
         self.is_equal_schema(schema, schema2)
 
-
     def is_equal_schema(self, schema, schema2, schema_path=None):
-        '''method to compare two colander schema for testing 
+        '''method to compare two colander schema for testing
         purposes
-        
+
          - does not compare preparer, validator, after_bind, missing_msg
          - does not do a proper comparison on widgets, but it is
            sufficient for this test suite
         '''
-        
+
         if schema_path is None:
             schema_path = []
         else:
@@ -940,12 +866,62 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         self.assertEqual(schema.missing, schema2.missing, msg=".".join(schema_path))
         self.assertEqual(schema.default, schema2.default, msg=".".join(schema_path))
         self.assertEqual(schema.widget, schema2.widget, msg=".".join(schema_path))
-        
         self.assertEqual(len(schema.children), len(schema2.children))
-        
+
         # test children and test that they're in the right order
         for i, node in enumerate(schema.children):
             self.assertEqual(node.name, schema2.children[i].name, msg=".".join(schema_path))
-            
             self.is_equal_schema(node, schema2.children[i], schema_path[:])
 
+    def test_specify_order_fields(self):
+        """
+        Test this issue:
+        How to specify the order in which fields should be displayed ? #45
+        """
+        Base = declarative_base()
+
+        # example taken from SQLAlchemy docs
+        class MyClass(Base):
+            __tablename__ = 'my_table'
+
+            id = Column(Integer, primary_key=True)
+            job_status = Column(String(50))
+
+            status = synonym("job_status")
+
+        schema = SQLAlchemySchemaNode(MyClass,
+                                      includes=['foo', 'job_status', 'id'])
+        self.assertEqual(['job_status', 'id'], [x.name for x in schema])
+        self.assertNotIn('foo', schema)
+
+        schema = SQLAlchemySchemaNode(MyClass,
+                                      includes=['id', 'foo', 'job_status'])
+        self.assertEqual(['id', 'job_status'], [x.name for x in schema])
+        self.assertNotIn('foo', schema)
+
+    def test_non_text_includes(self):
+        """
+        TODO: need the doc there
+        """
+        Base = declarative_base()
+
+        # example taken from SQLAlchemy docs
+        class MyClass(Base):
+            __tablename__ = 'my_table'
+
+            id = Column(Integer, primary_key=True)
+            job_status = Column(String(50))
+
+            status = synonym("job_status")
+        typ = colander.String()
+        widget = deform.widget.SelectWidget(values=(('foo', 'a'),
+                                                    ('bar', 'b'),
+                                                    ('baz', 'c')))
+        column = colander.SchemaNode(typ,
+                                     name='customfield',
+                                     widget=widget)
+        schema = SQLAlchemySchemaNode(MyClass,
+                                      includes=['foo', 'job_status', column, 'id'])
+        self.assertEqual(['job_status', 'customfield', 'id'],
+                         [x.name for x in schema])
+        self.assertNotIn('foo', schema)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py26,py27,py32
+envlist = py26,py27,py32,py34
 
 [testenv]
 deps=coverage
+     deform
 commands=coverage erase
          coverage run --branch -m unittest discover tests []
          coverage report --include=*colanderalchemy* -m
@@ -10,6 +11,7 @@ commands=coverage erase
 [testenv:py26]
 deps=unittest2
      coverage
+     deform
 commands=coverage erase
          coverage run --branch -m unittest2 discover tests []
          coverage report --include=*colanderalchemy* -m


### PR DESCRIPTION
I added some futures that solve #45 issue and makes customizing form of a more flexible. For example, I can add  my own column to form:

    import deform
    import colander
    from colanderalchemy import SQLAlchemySchemaNode
    from my.project import SomeClass

    typ = colander.String()
    widget = deform.widget.SelectWidget(values=(('foo', 'a'),
                                                ('bar', 'b'),
                                                ('baz', 'c')))
    column = colander.SchemaNode(typ,
                                 name='customfield',
                                 widget=widget)
    schema = SQLAlchemySchemaNode(SomeClass,
                                  includes=['name', column, 'biography'],
                                  excludes=['id'],
                                  title='Some class')