### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,1 @@
-[egg_info]
-tag_build =
-tag_svn_revision = true
+


### PR DESCRIPTION
We're not using subversion so tagging it with the svn revision doesn't make a lot of sense any more.

I noticed when I tried to install ColanderAlchemy using setuptools that it versioned it as "0.3.2.dev1-r0" which violates the PEP440 and gives a warning now.