### PR TITLE
Make it possible to set "unknown" using __colanderalchemy_config__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,10 @@ Change Log
   `#70 <https://github.com/stefanofontanelli/ColanderAlchemy/pull/70>`_)
   [uralbash]
 - Allow setting ColanderAlchemy options in sqlalchemy type. [pieterproigia]
-
+- Make it possible to set the ``unknown`` ``colander.Mapping`` option
+  using ``__colanderalchemy_config__`` (PR
+  `#78 <https://github.com/stefanofontanelli/ColanderAlchemy/pull/78>`_)
+  [elemoine]
 
 0.3.1 (2014-03-19)
 ------------------

--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -69,6 +69,23 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
                    __colanderalchemy_config__ = {'title': 'Custom title',
                                                  'description': 'Sample'}
                    ...
+
+           The ``unknown`` argument passed to :class:`colander.Mapping`, which
+           defaults to ``'ignore'``, can be set by adding an ``unknown`` key to
+           the ``__colanderalchemy_config__`` dict. For example::
+
+               class MyModel(Base):
+                   __colanderalchemy_config__ = {'title': 'Custom title',
+                                                 'description': 'Sample',
+                                                 'unknown': 'preserve'}
+                   ...
+
+           In contrast to the other options in ``__colanderalchemy_config__``,
+           the ``unknown`` option is not directly passed to
+           :class:`colander.SchemaNode`. Instead, it is passed to the
+           :class:`colander.Mapping` object, which itself is passed to
+           :class:`colander.SchemaNode`.
+
         includes
            Iterable of attributes to include from the resulting schema. Using
            this option will ensure *only* the explicitly mentioned attributes
@@ -113,6 +130,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
 
         # Obtain configuration specific from the mapped class
         kwargs.update(getattr(self.inspector.class_, self.ca_class_key, {}))
+        unknown = kwargs.pop('unknown', unknown)
 
         # The default type of this SchemaNode is Mapping.
         super(SQLAlchemySchemaNode, self).__init__(Mapping(unknown), **kwargs)

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -97,8 +97,14 @@ dict-like structure of options that will be passed to
     class Address(Base):
         __colanderalchemy_config__ = {'title': 'An address',
                                       'description': 'Enter an address.',
-                                      'validator': address_validator}
+                                      'validator': address_validator,
+                                      'unknown': 'preserve'}
         # Other SQLAlchemy columns are defined here
+
+Note that, in contrast to the other options in ``__colanderalchemy_config__``,
+the ``unknown`` option is not directly passed to :class:`colander.SchemaNode`.
+Instead, it is passed to the :class:`colander.Mapping` object, which itself is
+passed to :class:`colander.SchemaNode`.
 
 It is also possible to customize the column type, this is done in the same
 manner as above, using the ``__colanderalchemy_config__`` attribute, like so:

--- a/tests/models.py
+++ b/tests/models.py
@@ -42,7 +42,8 @@ def has_unique_addresses(node, value):
 class Account(Base):
 
     __tablename__ = 'accounts'
-    __colanderalchemy_config__ = {'preparer': 'DummyPreparer'}
+    __colanderalchemy_config__ = {'preparer': 'DummyPreparer',
+                                  'unknown': 'raise'}
     email = Column(Unicode(64), primary_key=True)
     enabled = Column(Boolean, default=True)
     created = Column(DateTime, nullable=True,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -492,6 +492,7 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         """
         schema = SQLAlchemySchemaNode(Account)
         self.assertEqual(schema.preparer, 'DummyPreparer')
+        self.assertEqual(schema.typ.unknown, 'raise')
 
         # Related models will be configured as well
         self.assertEqual(schema['person'].widget, 'DummyWidget')


### PR DESCRIPTION
This commit makes it possible to set the `unknown` argument passed to `colander.Mapping` using `__colanderalchemy_config__`. This is useful when one wants to set `unknown` (to `'raise'` or `'preserve'`) for classes used in a relationship.

Please tell me if more changes are required.