### PR TITLE
improve error message

### DIFF
--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -303,7 +303,12 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
             type_ = colander.Time()
 
         else:
-            raise NotImplementedError('Unknown type: %s' % column_type)
+            raise NotImplementedError(
+                'Not able to derive a colander type from sqlalchemy '
+                'type: %s  Please explicitly provide a colander '
+                '`typ` for the "%s" Column.'
+                % (repr(column_type), name)
+            )
 
         """
         Add default values


### PR DESCRIPTION
When using a sqlalchemy type that can't be easily typed into a
colander type, we throw a NotImplementedError that seems like
a brick wall.  I've changed it to suggest that the developer
explicitly provide a colander type for the column.  This came
up as part of issue #66.