### PR TITLE
Handle colander.null for mapped schemas in objectify

### DIFF
--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -695,7 +695,10 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
                                  for obj in dict_[attr]]
                     else:
                         # Single object
-                        value = self[attr].objectify(dict_[attr])
+                        if dict_[attr] is colander.null:
+                            value = None
+                        else:
+                            value = self[attr].objectify(dict_[attr])
                 else:
                      value = dict_[attr]
                      if value is colander.null:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -528,6 +528,34 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         self.assertEqual(person.fullname, None)
         self.assertEqual(person.age, None)
 
+    def test_objectify_null(self):
+        """ Make sure that `colander.null` is replaced with `None` for
+        mapped schemas.
+        """
+        Base = declarative_base()
+
+        class DocumentGeometry(Base):
+            __tablename__ = 'document_geometries'
+            id = Column(Integer, primary_key=True)
+            document_id = Column(
+                Integer, ForeignKey('documents.document_id'),
+                nullable=False)
+            geom = Column(String)
+
+        class Document(Base):
+            __tablename__ = 'documents'
+
+            document_id = Column(Integer, primary_key=True)
+            geometry = relationship(DocumentGeometry, uselist=False)
+
+        schema = SQLAlchemySchemaNode(Document)
+
+        dict_ = schema.dictify(Document(geometry=None))
+        self.assertEqual(dict_['geometry'], colander.null)
+
+        obj = schema.objectify(dict_)
+        self.assertEqual(obj.geometry, None)
+
     def test_objectify_context(self):
         """ Test converting a data structure into objects, using a context.
         """


### PR DESCRIPTION
I am having a schema like the following:

        class DocumentGeometry(Base):
            __tablename__ = 'document_geometries'
            id = Column(Integer, primary_key=True)
            document_id = Column(
                Integer, ForeignKey('documents.document_id'),
                nullable=False)
            geom = Column(String)

        class Document(Base):
            __tablename__ = 'documents'

            document_id = Column(Integer, primary_key=True)
            geometry = relationship(DocumentGeometry, uselist=False)

        schema = SQLAlchemySchemaNode(Document)

When I try to use `schema.objectify({geometry: colander.null, document_id: null})`, I was seeing the following error message:

        value = self[attr].objectify(dict_[attr])
      File ".../ColanderAlchemy/colanderalchemy/schema.py", line 687, in objectify
        for attr in dict_:
    TypeError: '_null' object is not iterable

When the value for attribute `geometry` is `colander.null`, `None` should simply be used as value instead of trying to call `objectify` with it.