### PR TITLE
Support postgresql.ARRAY

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     Unicode,
     event
 )
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import (relationship, mapper)
 
@@ -64,6 +65,7 @@ class Person(Base):
     gender = Column(Enum('M', 'F'), nullable=False)
     birthday = Column(Date, nullable=True)
     age = Column(Integer, nullable=True)
+    phone_numbers = Column(ARRAY(Unicode(32)))
     addresses = relationship(
         'Address',
         info={

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -370,7 +370,9 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
     def _prep_schema(self):
         overrides = {
             'person': {
-                'includes': ['name', 'surname', 'gender', 'addresses'],
+                'includes': [
+                    'name', 'surname', 'gender', 'addresses', 'phone_numbers'
+                ],
                 'overrides': {
                     'addresses': {
                         'includes': ['street', 'city'],
@@ -403,7 +405,8 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         address = Address(**address_args)
 
         person_args = dict(name='My Name', surname='My Surname',
-                           gender='M', addresses=[address])
+                           gender='M', addresses=[address],
+                           phone_numbers=['+12345', '+234567'])
         person = Person(**person_args)
 
         account_args = dict(email='mailbox@domain.tld',
@@ -476,7 +479,8 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
                     'city': 'My City',
                     'street': 'My Street'
                 }],
-                'name': 'My Name'
+                'name': 'My Name',
+                'phone_numbers': ['+123', '+234']
             },
             'enabled': True,
             'email': 'mailbox@domain.tld',


### PR DESCRIPTION
This PR adds support for the type [postgresql.ARRAY](http://docs.sqlalchemy.org/en/latest/dialects/postgresql.html#sqlalchemy.dialects.postgresql.ARRAY). Once SQLAlchemy 1.1.0 is released, the more generic type [Array](http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.Array) can be used.

Feedback is welcome because I am not 100% confident with the change.