### PR TITLE
Allow includes to support dot notation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change Log
 0.3.4.dev1 (unreleased)
 -----------------------
 
-
+- Allow dot notation for includes to explicitly restrict recursive schema creation
 
 0.3.3 (2015-07-20)
 ------------------

--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -453,6 +453,10 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
             override imperatively. Values provides as part of :attr:`overrides`
             will take precendence over all others.  Example keys include
             ``children``, ``includes``, ``excludes``, ``overrides``.
+        includes
+            A list of strings that specify which nodes of the relationship
+            to include. A value of None will inspect the overrides for
+            includes. Defaults to None.
         """
 
         # The name of the SchemaNode is the ColumnProperty key.

--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -198,8 +198,8 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
                     property_includes = None
                 node = self.get_schema_from_relationship(
                     prop,
-                    property_includes,
-                    name_overrides_copy
+                    name_overrides_copy,
+                    property_includes
                 )
             elif isinstance(prop, colander.SchemaNode):
                 node = prop
@@ -420,7 +420,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
         if msg:
             raise ValueError(msg % (name, arg))
 
-    def get_schema_from_relationship(self, prop, includes, overrides):
+    def get_schema_from_relationship(self, prop, overrides, includes=None):
         """ Build and return a :class:`colander.SchemaNode` for a relationship.
 
         The mapping process will translate one-to-many and many-to-many

--- a/colanderalchemy/schema.py
+++ b/colanderalchemy/schema.py
@@ -193,8 +193,12 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
             elif isinstance(prop, RelationshipProperty):
                 if prop.mapper.class_ in self.parents_ and name not in includes:
                     continue
+                property_includes = [ '.'.join(inc.split('.')[1:]) for inc in includes if inc.split('.')[0] == name and len(inc.split('.')) > 1 ]
+                if len(property_includes) == 0:
+                    property_includes = None
                 node = self.get_schema_from_relationship(
                     prop,
+                    property_includes,
                     name_overrides_copy
                 )
             elif isinstance(prop, colander.SchemaNode):
@@ -416,7 +420,7 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
         if msg:
             raise ValueError(msg % (name, arg))
 
-    def get_schema_from_relationship(self, prop, overrides):
+    def get_schema_from_relationship(self, prop, includes, overrides):
         """ Build and return a :class:`colander.SchemaNode` for a relationship.
 
         The mapping process will translate one-to-many and many-to-many
@@ -488,17 +492,14 @@ class SQLAlchemySchemaNode(colander.SchemaNode):
         imperative_includes = overrides.pop(key, None)
         declarative_includes = declarative_overrides.pop(key, None)
         if imperative_includes is not None:
-            includes = imperative_includes
+            includes = includes or imperative_includes
             msg = 'Relationship %s: %s overridden imperatively.'
             log.debug(msg, name, key)
 
         elif declarative_includes is not None:
-            includes = declarative_includes
+            includes = includes or declarative_includes
             msg = 'Relationship %s: %s overridden via declarative.'
             log.debug(msg, name, key)
-
-        else:
-            includes = None
 
         key = 'excludes'
         imperative_excludes = overrides.pop(key, None)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -41,6 +41,7 @@ from tests.models import (Account,
                           Bar,
                           Baz,
                           has_unique_addresses)
+from tests.transit_models import Route
 
 if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     # In Python < 2.7 use unittest2.
@@ -1368,3 +1369,13 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
         # Unpatched, creating a bar or baz schema node causes infinite recursion
         schema = SQLAlchemySchemaNode(Bar)
         schema = SQLAlchemySchemaNode(Baz)
+
+    def test_transit_dictify(self):
+        schema = SQLAlchemySchemaNode(Route, includes=['id', 'directions', 'directions.id', 'directions.patterns', 'directions.patterns.id', 'directions.patterns.locations'])
+        direction_sequence_schema = schema.get('directions', None)
+        direction_schema = direction_sequence_schema.get('directions', None)
+        pattern_sequence_schema = direction_schema.get('patterns', None)
+        pattern_schema = pattern_sequence_schema.get('patterns', None)
+        self.assertTrue(pattern_schema is not None)
+        routes_sequence_schema = direction_schema.get('routes', None)
+        self.assertTrue(routes_sequence_schema is None)

--- a/tests/transit_models.py
+++ b/tests/transit_models.py
@@ -1,0 +1,118 @@
+import sqlalchemy
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from tests.models import Base
+
+
+class Route(Base):
+
+    __tablename__ = 'route'
+
+    id = Column(Integer, primary_key=True)
+    route_directions = relationship('RouteDirection')
+    directions = relationship('Direction', secondary='route_direction', uselist=True)
+    patterns = relationship('Pattern', secondary='route_direction', uselist=True)
+
+
+class Direction(Base):
+
+    __tablename__ = 'direction'
+
+    id = Column(Integer, primary_key=True)
+    route_directions = relationship('RouteDirection')
+    routes = relationship('Route', secondary='route_direction', uselist=True)
+    patterns = relationship('Pattern', secondary='route_direction', uselist=True)
+
+
+class RouteDirection(Base):
+
+    __tablename__ = 'route_direction'
+
+    id = Column(Integer, primary_key=True)
+    route_id = Column(ForeignKey('route.id'))
+    direction_id = Column(ForeignKey('direction.id'))
+    route = relationship('Route')
+    direction = relationship('Direction')
+    patterns = relationship('Pattern', uselist=True)
+
+
+class Pattern(Base):
+
+    __tablename__ = 'pattern'
+
+    id = Column(Integer, primary_key=True)
+    route_direction_id = Column(ForeignKey('route_direction.id'))
+    route_direction = relationship('RouteDirection')
+    pattern_locations = relationship('PatternLocation', order_by='PatternLocation.order', uselist=True)
+    locations = relationship('Location', secondary='pattern_location', uselist=True)
+
+
+class PatternLocation(Base):
+
+    __tablename__ = 'pattern_location'
+
+    id = Column(Integer, primary_key=True)
+    pattern_id = Column(ForeignKey('pattern.id'))
+    order = Column(Integer)
+    location_id = Column(ForeignKey('location.id'))
+    pattern = relationship('Pattern')
+    location = relationship('Location')
+
+
+class Block(Base):
+
+    __tablename__ = 'block'
+
+    id = Column(Integer, primary_key=True)
+
+
+class Trip(Base):
+
+    __tablename__ = 'trip'
+
+    id = Column(Integer, primary_key=True)
+    pattern_id = Column(ForeignKey('pattern.id'))
+    block_id = Column(ForeignKey('block.id'))
+    pattern = relationship('Pattern')
+    block = relationship('Block')
+
+
+class TripStop(Base):
+
+    __tablename__ = 'trip_stop'
+
+    id = Column(Integer, primary_key=True)
+    trip_id = Column(ForeignKey('trip.id'))
+    trip = relationship('Trip')
+
+
+class TripStopLocation(Base):
+
+    __tablename__ = 'trip_stop_location'
+
+    id = Column(Integer, primary_key=True)
+    trip_stop_id = Column(ForeignKey('trip_stop.id'))
+    location_id = Column(ForeignKey('location.id'))
+    trip_stop = relationship('TripStop')
+    location = relationship('Location')
+
+
+class Location(Base):
+
+    __tablename__ = 'location'
+
+    id = Column(Integer, primary_key=True)
+    location_type_id = Column(ForeignKey('location_type.id'))
+    pattern_locations = relationship('PatternLocation', uselist=True)
+    patterns = relationship('Pattern', secondary='pattern_location', uselist=True)
+    trip_stop_locations = relationship('TripStopLocation', uselist=True)
+    trip_stops = relationship('TripStop', secondary='trip_stop_location', uselist=True)
+    location_type = relationship('LocationType')
+
+
+class LocationType(Base):
+
+    __tablename__ = 'location_type'
+
+    id = Column(Integer, primary_key=True)


### PR DESCRIPTION
Added complex schema and new test for new functionality

If test is ran to generate full Route schema, it creates 113 total
SQLAlchemySchemaNode objects as it traverses all relationships. For
small orms this may not be an issue, but the problem gets exponentially
worse as the size of the orm grows. This commit will enable users to
explicitly state which relationships and columns to include in subnodes
by allowing for dot-notation syntax in the includes keyword arg.

Resolves: #97