### PR TITLE
docs: fix simple typo, follwing -> following

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -647,7 +647,7 @@ class TestsSQLAlchemySchemaNode(unittest.TestCase):
 
         class User(Base):
             __tablename__ = 'user'
-            # the follwing is automatically made autoincrement=True
+            # the following is automatically made autoincrement=True
             id = Column(Integer, primary_key=True)
 
         schema = SQLAlchemySchemaNode(User)


### PR DESCRIPTION
There is a small typo in tests/test_schema.py.

Should read `following` rather than `follwing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md